### PR TITLE
fix: avoid empty value for service select

### DIFF
--- a/src/components/InstanceForm.tsx
+++ b/src/components/InstanceForm.tsx
@@ -168,12 +168,17 @@ export function InstanceForm({ instance, onSubmit, onCancel }: InstanceFormProps
 
         <div className="space-y-2">
           <Label htmlFor="service_id">Serviço</Label>
-          <Select value={formData.service_id || ""} onValueChange={(value) => handleInputChange("service_id", value)}>
+          <Select
+            value={formData.service_id || ""}
+            onValueChange={(value) =>
+              handleInputChange("service_id", value === "none" ? "" : value)
+            }
+          >
             <SelectTrigger>
               <SelectValue placeholder="Selecione um serviço (opcional)" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="">Nenhum serviço</SelectItem>
+              <SelectItem value="none">Nenhum serviço</SelectItem>
               {services.map((service) => (
                 <SelectItem key={service.id} value={service.id}>
                   {service.name}


### PR DESCRIPTION
## Summary
- prevent Radix Select from using an empty value for the "Nenhum serviço" option
- map the placeholder selection back to an empty service id

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 5 errors, 10 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6a12f2f58832a88880e8c7f183715