### PR TITLE
feat: add quick edit action

### DIFF
--- a/src/components/InstanceDashboard.tsx
+++ b/src/components/InstanceDashboard.tsx
@@ -15,7 +15,14 @@ import { useInstances } from "@/hooks/useInstances";
 import { useProxies } from "@/hooks/useProxies";
 import { useServices } from "@/hooks/useServices";
 import { useAuth } from "@/hooks/useAuth";
-import { Instance, CreateInstanceData, CreateProxyData, Service, CreateServiceData } from "@/types/instance";
+import {
+  Instance,
+  CreateInstanceData,
+  CreateProxyData,
+  Service,
+  CreateServiceData,
+  InstanceStatus,
+} from "@/types/instance";
 import { useToast } from "@/hooks/use-toast";
 import { downloadPpx } from "@/utils/ppx-generator";
 
@@ -85,6 +92,17 @@ export function InstanceDashboard() {
       await deleteInstance(instanceId);
     } catch (error) {
       console.error("Error deleting instance:", error);
+    }
+  };
+
+  const handleQuickEditInstance = async (
+    instanceId: string,
+    data: { service_id: string | null; status: InstanceStatus }
+  ) => {
+    try {
+      await updateInstance(instanceId, data);
+    } catch (error) {
+      console.error("Error quick editing instance:", error);
     }
   };
 
@@ -417,6 +435,8 @@ export function InstanceDashboard() {
             ) : (
               <InstanceTable
                 instances={filteredInstances}
+                services={services}
+                onQuickEdit={handleQuickEditInstance}
                 onEdit={setEditingInstance}
                 onDelete={handleDeleteInstance}
               />

--- a/src/types/instance.ts
+++ b/src/types/instance.ts
@@ -26,7 +26,7 @@ export interface Instance {
   pid1: string;
   pid2: string;
   proxy_id: string;
-  service_id?: string;
+  service_id?: string | null;
   status: InstanceStatus;
   created_at: string;
   updated_at: string;
@@ -40,7 +40,7 @@ export interface CreateInstanceData {
   pid1: string;
   pid2: string;
   proxy_id: string;
-  service_id?: string;
+  service_id?: string | null;
   status: InstanceStatus;
 }
 


### PR DESCRIPTION
## Summary
- allow quick editing service and status from instance list
- support nullable service reference

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-require-imports)

------
https://chatgpt.com/codex/tasks/task_e_68b6a49da14c832ab6c8cde768d2338f