### PR TITLE
fix: handle select placeholder and dialog accessibility

### DIFF
--- a/src/components/InstanceForm.tsx
+++ b/src/components/InstanceForm.tsx
@@ -169,7 +169,7 @@ export function InstanceForm({ instance, onSubmit, onCancel }: InstanceFormProps
         <div className="space-y-2">
           <Label htmlFor="service_id">Serviço</Label>
           <Select
-            value={formData.service_id || ""}
+            value={formData.service_id || undefined}
             onValueChange={(value) =>
               handleInputChange("service_id", value === "none" ? "" : value)
             }

--- a/src/components/InstanceTable.tsx
+++ b/src/components/InstanceTable.tsx
@@ -8,6 +8,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import {
@@ -69,13 +70,13 @@ export function InstanceTable({
 }: InstanceTableProps) {
   const [visiblePasswords, setVisiblePasswords] = useState<Set<string>>(new Set());
   const [quickEditInstance, setQuickEditInstance] = useState<Instance | null>(null);
-  const [selectedService, setSelectedService] = useState<string>("");
+  const [selectedService, setSelectedService] = useState<string | undefined>(undefined);
   const [selectedStatus, setSelectedStatus] = useState<InstanceStatus>("Repouso");
   const { toast } = useToast();
 
   const openQuickEdit = (instance: Instance) => {
     setQuickEditInstance(instance);
-    setSelectedService(instance.service_id || "");
+    setSelectedService(instance.service_id || undefined);
     setSelectedStatus(instance.status);
   };
 
@@ -350,16 +351,24 @@ export function InstanceTable({
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Edição rápida</DialogTitle>
+          <DialogDescription>
+            Atualize rapidamente o serviço e o estado da instância.
+          </DialogDescription>
         </DialogHeader>
         <div className="space-y-4">
           <div className="space-y-2">
             <Label>Serviço</Label>
-            <Select value={selectedService} onValueChange={setSelectedService}>
+            <Select
+              value={selectedService}
+              onValueChange={(value) =>
+                setSelectedService(value === "none" ? undefined : value)
+              }
+            >
               <SelectTrigger>
                 <SelectValue placeholder="Nenhum serviço" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="">Nenhum serviço</SelectItem>
+                <SelectItem value="none">Nenhum serviço</SelectItem>
                 {services.map((service) => (
                   <SelectItem key={service.id} value={service.id}>
                     {service.name}

--- a/src/components/PidTracker.tsx
+++ b/src/components/PidTracker.tsx
@@ -1,6 +1,13 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogDescription,
+} from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -114,6 +121,9 @@ export function PidTracker({ instances, onUpdatePids }: PidTrackerProps) {
       <DialogContent className="max-w-4xl max-h-[80vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Rastreamento de PIDs</DialogTitle>
+          <DialogDescription>
+            Cole ou importe os dados dos PIDs para atribuí-los às instâncias.
+          </DialogDescription>
         </DialogHeader>
 
         {step === 'input' ? (
@@ -168,8 +178,10 @@ export function PidTracker({ instances, onUpdatePids }: PidTrackerProps) {
                       <ArrowRight className="h-4 w-4 text-muted-foreground" />
                       <div className="flex-1">
                         <Select
-                          value={assignments[pid.instanceNumber] || ''}
-                          onValueChange={(value) => handleAssignmentChange(pid.instanceNumber, value)}
+                          value={assignments[pid.instanceNumber] || undefined}
+                          onValueChange={(value) =>
+                            handleAssignmentChange(pid.instanceNumber, value)
+                          }
                         >
                           <SelectTrigger>
                             <SelectValue placeholder="Selecionar instância" />


### PR DESCRIPTION
## Summary
- prevent crash by avoiding empty SelectItem value and using `none` placeholder
- add descriptions to dialogs for better accessibility
- handle optional service selection without empty values

## Testing
- `npx eslint src/components/InstanceTable.tsx src/components/PidTracker.tsx src/components/InstanceForm.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6a77927d0832ab7fe516bfae468b8