### PR TITLE
feat: add instance phone number field

### DIFF
--- a/src/components/InstanceDashboard.tsx
+++ b/src/components/InstanceDashboard.tsx
@@ -97,7 +97,7 @@ export function InstanceDashboard() {
 
   const handleQuickEditInstance = async (
     instanceId: string,
-    data: { service_id: string | null; status: InstanceStatus }
+    data: { service_id: string | null; status: InstanceStatus; phone_number?: string | null }
   ) => {
     try {
       await updateInstance(instanceId, data);

--- a/src/components/InstanceForm.tsx
+++ b/src/components/InstanceForm.tsx
@@ -24,6 +24,7 @@ export function InstanceForm({ instance, onSubmit, onCancel }: InstanceFormProps
     instance_number: 1,
     pid1: "0000",
     pid2: "0000",
+    phone_number: "",
     proxy_id: "",
     service_id: "",
     status: "Repouso",
@@ -48,6 +49,7 @@ export function InstanceForm({ instance, onSubmit, onCancel }: InstanceFormProps
         instance_number: instance.instance_number,
         pid1: instance.pid1,
         pid2: instance.pid2,
+        phone_number: instance.phone_number || "",
         proxy_id: instance.proxy_id,
         service_id: instance.service_id || "",
         status: instance.status,
@@ -164,6 +166,16 @@ export function InstanceForm({ instance, onSubmit, onCancel }: InstanceFormProps
           {errors.instance_number && (
             <p className="text-sm text-destructive">{errors.instance_number}</p>
           )}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="phone_number">Telefone</Label>
+          <Input
+            id="phone_number"
+            value={formData.phone_number || ""}
+            onChange={(e) => handleInputChange("phone_number", e.target.value)}
+            placeholder="(00) 00000-0000"
+          />
         </div>
 
         <div className="space-y-2">

--- a/src/components/InstanceTable.tsx
+++ b/src/components/InstanceTable.tsx
@@ -11,6 +11,7 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -55,7 +56,7 @@ interface InstanceTableProps {
   services: Service[];
   onQuickEdit: (
     instanceId: string,
-    data: { service_id: string | null; status: InstanceStatus }
+    data: { service_id: string | null; status: InstanceStatus; phone_number?: string | null }
   ) => void;
   onEdit: (instance: Instance) => void;
   onDelete: (instanceId: string) => void;
@@ -72,12 +73,14 @@ export function InstanceTable({
   const [quickEditInstance, setQuickEditInstance] = useState<Instance | null>(null);
   const [selectedService, setSelectedService] = useState<string | undefined>(undefined);
   const [selectedStatus, setSelectedStatus] = useState<InstanceStatus>("Repouso");
+  const [selectedPhone, setSelectedPhone] = useState<string>("");
   const { toast } = useToast();
 
   const openQuickEdit = (instance: Instance) => {
     setQuickEditInstance(instance);
     setSelectedService(instance.service_id || undefined);
     setSelectedStatus(instance.status);
+    setSelectedPhone(instance.phone_number || "");
   };
 
   const handleQuickEditSave = () => {
@@ -85,6 +88,7 @@ export function InstanceTable({
       onQuickEdit(quickEditInstance.id, {
         service_id: selectedService || null,
         status: selectedStatus,
+        phone_number: selectedPhone || null,
       });
       setQuickEditInstance(null);
     }
@@ -182,6 +186,7 @@ export function InstanceTable({
                       {instance.instance_name}
                     </p>
                     <p className="text-xs text-muted-foreground">
+                      {instance.phone_number ? `Tel: ${instance.phone_number} • ` : ""}
                       Criado: {new Date(instance.created_at).toLocaleDateString('pt-BR')}
                     </p>
                   </div>
@@ -356,6 +361,14 @@ export function InstanceTable({
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-4">
+          <div className="space-y-2">
+            <Label>Telefone</Label>
+            <Input
+              value={selectedPhone}
+              onChange={(e) => setSelectedPhone(e.target.value)}
+              placeholder="(00) 00000-0000"
+            />
+          </div>
           <div className="space-y-2">
             <Label>Serviço</Label>
             <Select

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -22,6 +22,7 @@ export type Database = {
           instance_number: number
           pid1: string
           pid2: string
+          phone_number: string | null
           ppx_proxy_id: number | null
           ppx_rule_order: number | null
           proxy_id: string
@@ -41,6 +42,7 @@ export type Database = {
           instance_number: number
           pid1?: string
           pid2?: string
+          phone_number?: string | null
           ppx_proxy_id?: number | null
           ppx_rule_order?: number | null
           proxy_id: string
@@ -60,6 +62,7 @@ export type Database = {
           instance_number?: number
           pid1?: string
           pid2?: string
+          phone_number?: string | null
           ppx_proxy_id?: number | null
           ppx_rule_order?: number | null
           proxy_id?: string

--- a/src/types/instance.ts
+++ b/src/types/instance.ts
@@ -25,6 +25,7 @@ export interface Instance {
   instance_name: string;
   pid1: string;
   pid2: string;
+  phone_number?: string | null;
   proxy_id: string;
   service_id?: string | null;
   status: InstanceStatus;
@@ -39,6 +40,7 @@ export interface CreateInstanceData {
   instance_number: number;
   pid1: string;
   pid2: string;
+  phone_number?: string | null;
   proxy_id: string;
   service_id?: string | null;
   status: InstanceStatus;

--- a/supabase/migrations/20250902070000_add_instance_phone.sql
+++ b/supabase/migrations/20250902070000_add_instance_phone.sql
@@ -1,0 +1,2 @@
+-- Add optional phone number to instances
+ALTER TABLE instances ADD COLUMN phone_number TEXT;


### PR DESCRIPTION
## Summary
- show instance phone number alongside creation date in dashboard
- allow editing phone number during instance creation and quick edit
- add optional phone number column to instances table

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6aa4013b4832a96fccac2936da207