### PR TITLE
Rename default PPX rule label

### DIFF
--- a/src/utils/ppx-generator.ts
+++ b/src/utils/ppx-generator.ts
@@ -53,11 +53,11 @@ const PPX_TEMPLATE = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 		<!-- END:DYNAMIC_RULE_LIST -->
 
 		<!-- STATIC: Regra default sempre apontando para CONECTANDO (id 104). Não remover. -->
-		<Rule enabled="true">
-			<Action type="Proxy">104</Action>
-			<Name>CONECTANDO (Default)</Name>
-		</Rule>
-	</RuleList>
+                <Rule enabled="true">
+                        <Action type="Proxy">104</Action>
+                        <Name>Default</Name>
+                </Rule>
+        </RuleList>
 </ProxifierProfile>`;
 
 interface InstanceRow {


### PR DESCRIPTION
## Summary
- rename default rule label in PPX template from "CONECTANDO (Default)" to "Default"

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 5 errors, 10 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68b6b50e6850832a9efd57bce4539ccc