### PR TITLE
feat: bulk edit service and status

### DIFF
--- a/src/components/BulkImportForm.tsx
+++ b/src/components/BulkImportForm.tsx
@@ -87,14 +87,14 @@ export function BulkImportForm({ onSubmit, onCancel }: BulkImportFormProps) {
           throw new Error(`Linha ${i + 1}: número de colunas não confere com o cabeçalho`);
         }
 
-        const instance: any = {};
-        header.forEach((col, idx) => {
-          if (col === 'instance_number' || col === 'proxy_port') {
-            instance[col] = parseInt(values[idx]) || 0;
-          } else {
-            instance[col] = values[idx] || "";
-          }
-        });
+          const instance: Partial<BulkImportInstance> = {};
+          header.forEach((col, idx) => {
+            if (col === 'instance_number' || col === 'proxy_port') {
+              instance[col] = parseInt(values[idx]) || 0;
+            } else {
+              instance[col] = values[idx] || "";
+            }
+          });
 
         // Validate required fields
         if (!instance.instance_name || !instance.proxy_name || !instance.proxy_ip) {

--- a/src/components/InstanceDashboard.tsx
+++ b/src/components/InstanceDashboard.tsx
@@ -43,7 +43,7 @@ export function InstanceDashboard() {
   console.log("InstanceDashboard: Component started rendering");
   
   const { user, signOut } = useAuth();
-  const { instances, loading, createInstance, updateInstance, deleteInstance, updatePids, clearAllPids } = useInstances();
+  const { instances, loading, createInstance, updateInstance, deleteInstance, updatePids, clearAllPids, bulkUpdateInstances } = useInstances();
   const { createProxy } = useProxies();
   const { services, createService, updateService, deleteService } = useServices();
   const { toast } = useToast();
@@ -121,6 +121,17 @@ export function InstanceDashboard() {
       await updateInstance(instanceId, data);
     } catch (error) {
       console.error("Error quick editing instance:", error);
+    }
+  };
+
+  const handleBulkEditInstances = async (
+    instanceIds: string[],
+    data: { service_id: string | null; status: InstanceStatus }
+  ) => {
+    try {
+      await bulkUpdateInstances(instanceIds, data);
+    } catch (error) {
+      console.error("Error bulk editing instances:", error);
     }
   };
 
@@ -455,6 +466,7 @@ export function InstanceDashboard() {
                 instances={filteredInstances}
                 services={services}
                 onQuickEdit={handleQuickEditInstance}
+                onBulkEdit={handleBulkEditInstances}
                 onEdit={setEditingInstance}
                 onDelete={handleDeleteInstance}
               />

--- a/src/components/InstanceTable.tsx
+++ b/src/components/InstanceTable.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -58,6 +59,7 @@ interface InstanceTableProps {
     instanceId: string,
     data: { service_id: string | null; status: InstanceStatus; phone_number?: string | null; instance_name?: string }
   ) => void;
+  onBulkEdit: (instanceIds: string[], data: { service_id: string | null; status: InstanceStatus }) => void;
   onEdit: (instance: Instance) => void;
   onDelete: (instanceId: string) => void;
 }
@@ -66,6 +68,7 @@ export function InstanceTable({
   instances,
   services,
   onQuickEdit,
+  onBulkEdit,
   onEdit,
   onDelete,
 }: InstanceTableProps) {
@@ -75,6 +78,10 @@ export function InstanceTable({
   const [selectedStatus, setSelectedStatus] = useState<InstanceStatus>("Repouso");
   const [selectedPhone, setSelectedPhone] = useState<string>("");
   const [selectedName, setSelectedName] = useState<string>("");
+  const [selectedInstances, setSelectedInstances] = useState<Set<string>>(new Set());
+  const [bulkEditOpen, setBulkEditOpen] = useState(false);
+  const [bulkService, setBulkService] = useState<string | undefined>(undefined);
+  const [bulkStatus, setBulkStatus] = useState<InstanceStatus>("Repouso");
   const { toast } = useToast();
 
   const openQuickEdit = (instance: Instance) => {
@@ -96,6 +103,45 @@ export function InstanceTable({
       setQuickEditInstance(null);
     }
   };
+
+  const toggleInstanceSelection = (id: string, checked: boolean) => {
+    setSelectedInstances(prev => {
+      const newSet = new Set(prev);
+      if (checked) {
+        newSet.add(id);
+      } else {
+        newSet.delete(id);
+      }
+      return newSet;
+    });
+  };
+
+  const toggleSelectAll = (checked: boolean) => {
+    if (checked) {
+      setSelectedInstances(new Set(instances.map(i => i.id)));
+    } else {
+      setSelectedInstances(new Set());
+    }
+  };
+
+  const handleBulkEditSave = () => {
+    onBulkEdit(Array.from(selectedInstances), {
+      service_id: bulkService || null,
+      status: bulkStatus,
+    });
+    setBulkEditOpen(false);
+    setSelectedInstances(new Set());
+    setBulkService(undefined);
+    setBulkStatus("Repouso");
+  };
+
+  const allSelected =
+    selectedInstances.size === instances.length && instances.length > 0;
+  const headerChecked = allSelected
+    ? true
+    : selectedInstances.size > 0
+      ? "indeterminate"
+      : false;
 
   const togglePasswordVisibility = (instanceId: string) => {
     setVisiblePasswords(prev => {
@@ -159,8 +205,22 @@ export function InstanceTable({
       <CardContent className="p-0">
         <div className="overflow-x-auto">
           <div className="min-w-full">
+            {selectedInstances.size > 0 && (
+              <div className="flex items-center justify-between p-2 bg-muted/30 border-b border-border/50">
+                <span className="text-sm">{selectedInstances.size} selecionada(s)</span>
+                <Button size="sm" variant="outline" onClick={() => setBulkEditOpen(true)}>
+                  Editar em Massa
+                </Button>
+              </div>
+            )}
             {/* Header */}
-            <div className="grid grid-cols-12 gap-4 p-4 bg-muted/20 border-b border-border/50 text-sm font-medium text-muted-foreground">
+            <div className="grid grid-cols-13 gap-4 p-4 bg-muted/20 border-b border-border/50 text-sm font-medium text-muted-foreground">
+              <div className="col-span-1 flex items-center">
+                <Checkbox
+                  checked={headerChecked}
+                  onCheckedChange={(checked) => toggleSelectAll(checked === true)}
+                />
+              </div>
               <div className="col-span-1">#</div>
               <div className="col-span-2">Instância</div>
               <div className="col-span-1">Serviço</div>
@@ -175,8 +235,14 @@ export function InstanceTable({
             {instances.map((instance) => (
               <div
                 key={instance.id}
-                className="grid grid-cols-12 gap-4 p-4 border-b border-border/20 hover:bg-muted/10 transition-colors"
+                className="grid grid-cols-13 gap-4 p-4 border-b border-border/20 hover:bg-muted/10 transition-colors"
               >
+                <div className="col-span-1 flex items-center">
+                  <Checkbox
+                    checked={selectedInstances.has(instance.id)}
+                    onCheckedChange={(checked) => toggleInstanceSelection(instance.id, checked === true)}
+                  />
+                </div>
                 <div className="col-span-1">
                   <Badge variant="outline" className="bg-primary/10 text-primary border-primary/20">
                     {instance.instance_number}
@@ -199,9 +265,9 @@ export function InstanceTable({
                 </div>
 
                 <div className="col-span-1">
-                  <Badge 
-                    variant="outline" 
-                    className="bg-accent/10 text-accent-foreground border-accent/20 text-xs truncate" 
+                  <Badge
+                    variant="outline"
+                    className="bg-accent/10 text-accent-foreground border-accent/20 text-xs truncate"
                     title={instance.services?.name || 'Nenhum serviço'}
                   >
                     {instance.services?.name || 'N/A'}
@@ -209,11 +275,11 @@ export function InstanceTable({
                 </div>
 
                 <div className="col-span-1">
-                  <Badge 
+                  <Badge
                     variant={
-                      instance.status === 'Disparando' ? 'destructive' : 
-                      instance.status === 'Aquecendo' ? 'default' : 
-                      instance.status === 'Banida' ? 'outline' : 
+                      instance.status === 'Disparando' ? 'destructive' :
+                      instance.status === 'Aquecendo' ? 'default' :
+                      instance.status === 'Banida' ? 'outline' :
                       'secondary'
                     }
                     className="text-xs"
@@ -329,7 +395,7 @@ export function InstanceTable({
                             <AlertDialogHeader>
                               <AlertDialogTitle>Confirmar exclusão</AlertDialogTitle>
                               <AlertDialogDescription>
-                                Tem certeza que deseja excluir a instância "{instance.instance_name}"? 
+                                Tem certeza que deseja excluir a instância "{instance.instance_name}"?
                                 Esta ação não pode ser desfeita.
                               </AlertDialogDescription>
                             </AlertDialogHeader>
@@ -427,6 +493,62 @@ export function InstanceTable({
             Cancelar
           </Button>
           <Button onClick={handleQuickEditSave}>Salvar</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+    <Dialog open={bulkEditOpen} onOpenChange={setBulkEditOpen}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edição em Massa</DialogTitle>
+          <DialogDescription>
+            Atualize o serviço e o estado das instâncias selecionadas.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label>Serviço</Label>
+            <Select
+              value={bulkService}
+              onValueChange={(value) =>
+                setBulkService(value === "none" ? undefined : value)
+              }
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Nenhum serviço" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">Nenhum serviço</SelectItem>
+                {services.map((service) => (
+                  <SelectItem key={service.id} value={service.id}>
+                    {service.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label>Estado</Label>
+            <Select
+              value={bulkStatus}
+              onValueChange={(value) => setBulkStatus(value as InstanceStatus)}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="Repouso">Repouso</SelectItem>
+                <SelectItem value="Aquecendo">Aquecendo</SelectItem>
+                <SelectItem value="Disparando">Disparando</SelectItem>
+                <SelectItem value="Banida">Banida</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setBulkEditOpen(false)}>
+            Cancelar
+          </Button>
+          <Button onClick={handleBulkEditSave}>Salvar</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/hooks/useInstances.ts
+++ b/src/hooks/useInstances.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { supabase } from "@/integrations/supabase/client";
-import { Instance, CreateInstanceData } from "@/types/instance";
+import { Instance, CreateInstanceData, InstanceStatus } from "@/types/instance";
 import { useToast } from "@/hooks/use-toast";
 
 export function useInstances() {
@@ -172,6 +172,34 @@ export function useInstances() {
     }
   };
 
+  const bulkUpdateInstances = async (
+    ids: string[],
+    data: { service_id: string | null; status: InstanceStatus }
+  ) => {
+    try {
+      const { error } = await supabase
+        .from('instances')
+        .update(data)
+        .in('id', ids);
+
+      if (error) throw error;
+
+      await fetchInstances();
+      toast({
+        title: "Instâncias atualizadas com sucesso",
+        description: `${ids.length} instância(s) foram atualizadas.`,
+      });
+    } catch (error) {
+      console.error('Error bulk updating instances:', error);
+      toast({
+        title: "Erro ao atualizar instâncias",
+        description: "Não foi possível atualizar as instâncias.",
+        variant: "destructive",
+      });
+      throw error;
+    }
+  };
+
   const updatePids = async (pidUpdates: { instanceId: string; pid1: string; pid2: string }[]) => {
     try {
       const promises = pidUpdates.map(update =>
@@ -241,6 +269,7 @@ export function useInstances() {
     updateInstance,
     deleteInstance,
     updatePids,
+    bulkUpdateInstances,
     clearAllPids,
     refetch: fetchInstances,
   };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -153,5 +154,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- enable bulk service and status updates via new `bulkUpdateInstances` hook
- allow selecting instances and updating service/status for all selected from table
- resolve template lint issues by replacing `any`, empty interfaces, and CommonJS imports

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6d7dbee1c832a9ed086d55454c86c