### PR TITLE
feat: add bulk instance editing and fix template

### DIFF
--- a/src/components/BulkImportForm.tsx
+++ b/src/components/BulkImportForm.tsx
@@ -87,14 +87,14 @@ export function BulkImportForm({ onSubmit, onCancel }: BulkImportFormProps) {
           throw new Error(`Linha ${i + 1}: número de colunas não confere com o cabeçalho`);
         }
 
-        const instance: any = {};
-        header.forEach((col, idx) => {
-          if (col === 'instance_number' || col === 'proxy_port') {
-            instance[col] = parseInt(values[idx]) || 0;
-          } else {
-            instance[col] = values[idx] || "";
-          }
-        });
+          const instance: Partial<BulkImportInstance> = {};
+          header.forEach((col, idx) => {
+            if (col === 'instance_number' || col === 'proxy_port') {
+              instance[col] = parseInt(values[idx]) || 0;
+            } else {
+              instance[col] = values[idx] || "";
+            }
+          });
 
         // Validate required fields
         if (!instance.instance_name || !instance.proxy_name || !instance.proxy_ip) {

--- a/src/components/InstanceDashboard.tsx
+++ b/src/components/InstanceDashboard.tsx
@@ -43,7 +43,7 @@ export function InstanceDashboard() {
   console.log("InstanceDashboard: Component started rendering");
   
   const { user, signOut } = useAuth();
-  const { instances, loading, createInstance, updateInstance, deleteInstance, updatePids, clearAllPids } = useInstances();
+  const { instances, loading, createInstance, updateInstance, deleteInstance, updatePids, clearAllPids, bulkUpdateInstances } = useInstances();
   const { createProxy } = useProxies();
   const { services, createService, updateService, deleteService } = useServices();
   const { toast } = useToast();
@@ -121,6 +121,17 @@ export function InstanceDashboard() {
       await updateInstance(instanceId, data);
     } catch (error) {
       console.error("Error quick editing instance:", error);
+    }
+  };
+
+  const handleBulkEditInstances = async (
+    instanceIds: string[],
+    data: { service_id: string | null; status: InstanceStatus }
+  ) => {
+    try {
+      await bulkUpdateInstances(instanceIds, data);
+    } catch (error) {
+      console.error("Error bulk editing instances:", error);
     }
   };
 
@@ -455,6 +466,7 @@ export function InstanceDashboard() {
                 instances={filteredInstances}
                 services={services}
                 onQuickEdit={handleQuickEditInstance}
+                onBulkEdit={handleBulkEditInstances}
                 onEdit={setEditingInstance}
                 onDelete={handleDeleteInstance}
               />

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/hooks/useProxies.ts
+++ b/src/hooks/useProxies.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { Proxy, CreateProxyData } from "@/types/instance";
 import { useToast } from "@/hooks/use-toast";
@@ -8,7 +8,7 @@ export function useProxies() {
   const [loading, setLoading] = useState(true);
   const { toast } = useToast();
 
-  const fetchProxies = async () => {
+  const fetchProxies = useCallback(async () => {
     try {
       const { data, error } = await supabase
         .from('proxies')
@@ -27,7 +27,7 @@ export function useProxies() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [toast]);
 
   const createProxy = async (proxyData: CreateProxyData) => {
     try {
@@ -113,7 +113,7 @@ export function useProxies() {
 
   useEffect(() => {
     fetchProxies();
-  }, []);
+  }, [fetchProxies]);
 
   return {
     proxies,

--- a/src/hooks/useServices.ts
+++ b/src/hooks/useServices.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { Service, CreateServiceData } from "@/types/instance";
 import { useToast } from "@/hooks/use-toast";
@@ -8,7 +8,7 @@ export function useServices() {
   const [loading, setLoading] = useState(true);
   const { toast } = useToast();
 
-  const fetchServices = async () => {
+  const fetchServices = useCallback(async () => {
     try {
       const { data, error } = await supabase
         .from('services')
@@ -27,7 +27,7 @@ export function useServices() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [toast]);
 
   const createService = async (serviceData: CreateServiceData) => {
     try {
@@ -113,7 +113,7 @@ export function useServices() {
 
   useEffect(() => {
     fetchServices();
-  }, []);
+  }, [fetchServices]);
 
   return {
     services,

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -153,5 +154,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add bulkUpdateInstances helper to update service and status across multiple instances
- wire bulk editing through dashboard and table with selection and dialog
- switch Tailwind config to ESM plugin import to restore template
- memoize fetch functions in hooks to satisfy lint

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6d7dbee1c832a9ed086d55454c86c