### PR TITLE
fix: count resting, warming, and firing instances as active

### DIFF
--- a/src/components/StatsCosts.tsx
+++ b/src/components/StatsCosts.tsx
@@ -26,7 +26,9 @@ export function StatsCosts({ instances }: StatsCostsProps) {
   }, {} as Record<InstanceStatus, number>);
 
   const activeInstancesCount =
-    (statusCounts["Aquecendo"] || 0) + (statusCounts["Disparando"] || 0);
+    (statusCounts["Repouso"] || 0) +
+    (statusCounts["Disparando"] || 0) +
+    (statusCounts["Aquecendo"] || 0);
 
   // Custos fixos
   const FIXED_COSTS = {


### PR DESCRIPTION
## Summary
- broaden active instance calculation to include `Aquecendo` status alongside `Repouso` and `Disparando`

## Testing
- `bun test`
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c40b56046c832a8cfb2e40693b3446