### PR TITLE
Handle CORS for webhook and improve dialog accessibility

### DIFF
--- a/src/components/AddToApiModal.tsx
+++ b/src/components/AddToApiModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -116,6 +116,9 @@ export function AddToApiModal({ instance, isOpen, onClose, onSuccess }: AddToApi
       <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle>Adicionar à API</DialogTitle>
+          <DialogDescription>
+            Preencha os dados abaixo para enviar a instância ao webhook externo.
+          </DialogDescription>
         </DialogHeader>
         
         <div className="space-y-4">

--- a/src/utils/webhook.ts
+++ b/src/utils/webhook.ts
@@ -18,10 +18,16 @@ export async function sendToApi(data: WebhookData): Promise<{ success: boolean; 
         'Content-Type': 'application/x-www-form-urlencoded',
       },
       body: formBody,
+      // O endpoint não fornece cabeçalhos CORS, por isso usamos `no-cors`
+      // para permitir que a requisição seja enviada sem que o navegador a bloqueie.
+      mode: 'no-cors',
     });
 
-    console.log('Response status:', response.status);
-    console.log('Response ok:', response.ok);
+    // Em requisições `no-cors` a resposta é opaca, portanto não é possível
+    // acessar o status ou o corpo. Se chegamos até aqui consideramos como sucesso.
+    if (response.type === 'opaque') {
+      return { success: true };
+    }
 
     if (!response.ok) {
       const errorText = await response.text().catch(() => 'Erro desconhecido');


### PR DESCRIPTION
## Summary
- Allow webhook requests without CORS headers by using `no-cors` mode and treating opaque responses as success
- Add dialog description in API modal to satisfy Radix UI requirements and avoid warnings

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c41fefc728832a9c5f90b41614037f