### PR TITLE
fix: avoid page reload on API send

### DIFF
--- a/src/components/InstanceDashboard.tsx
+++ b/src/components/InstanceDashboard.tsx
@@ -45,7 +45,17 @@ export function InstanceDashboard() {
   console.log("InstanceDashboard: Component started rendering");
   
   const { user, signOut } = useAuth();
-  const { instances, loading, createInstance, updateInstance, deleteInstance, updatePids, clearAllPids, bulkUpdateInstances } = useInstances();
+  const {
+    instances,
+    loading,
+    createInstance,
+    updateInstance,
+    deleteInstance,
+    updatePids,
+    clearAllPids,
+    bulkUpdateInstances,
+    refetch,
+  } = useInstances();
   const { createProxy } = useProxies();
   const { services, createService, updateService, deleteService } = useServices();
   const { toast } = useToast();
@@ -473,7 +483,7 @@ export function InstanceDashboard() {
                 onBulkEdit={handleBulkEditInstances}
                 onEdit={setEditingInstance}
                 onDelete={handleDeleteInstance}
-                onRefresh={() => window.location.reload()}
+                onRefresh={refetch}
               />
             )}
           </TabsContent>

--- a/src/utils/webhook.ts
+++ b/src/utils/webhook.ts
@@ -18,16 +18,7 @@ export async function sendToApi(data: WebhookData): Promise<{ success: boolean; 
         'Content-Type': 'application/x-www-form-urlencoded',
       },
       body: formBody,
-      // O endpoint não fornece cabeçalhos CORS, por isso usamos `no-cors`
-      // para permitir que a requisição seja enviada sem que o navegador a bloqueie.
-      mode: 'no-cors',
     });
-
-    // Em requisições `no-cors` a resposta é opaca, portanto não é possível
-    // acessar o status ou o corpo. Se chegamos até aqui consideramos como sucesso.
-    if (response.type === 'opaque') {
-      return { success: true };
-    }
 
     if (!response.ok) {
       const errorText = await response.text().catch(() => 'Erro desconhecido');
@@ -40,18 +31,18 @@ export async function sendToApi(data: WebhookData): Promise<{ success: boolean; 
     return { success: true };
   } catch (error) {
     console.error('Erro ao enviar para API:', error);
-    
+
     // Tratamento específico para diferentes tipos de erro
     if (error instanceof TypeError && error.message.includes('Failed to fetch')) {
-      return { 
-        success: false, 
-        error: 'Erro de conexão: Verifique se o webhook está disponível ou se há problemas de CORS' 
+      return {
+        success: false,
+        error: 'Erro de conexão: Verifique se o webhook está disponível ou se há problemas de CORS'
       };
     }
-    
-    return { 
-      success: false, 
-      error: error instanceof Error ? error.message : 'Erro desconhecido ao enviar para API' 
+
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Erro desconhecido ao enviar para API'
     };
   }
 }


### PR DESCRIPTION
## Summary
- refresh instances without reloading page after API send
- allow webhook errors to surface by removing `no-cors`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4219edab0832a9240edeb65f1e982