### PR TITLE
fix: configure fetch for CORS

### DIFF
--- a/src/utils/webhook.ts
+++ b/src/utils/webhook.ts
@@ -14,10 +14,12 @@ export async function sendToApi(data: WebhookData): Promise<{ success: boolean; 
     const formBody = new URLSearchParams(data as Record<string, string>).toString();
     const response = await fetch('https://webhook.site/96185f74-ccf8-4346-87dd-79ad87de924a', {
       method: 'POST',
+      mode: 'cors',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
       },
       body: formBody,
+      credentials: 'include',
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- set `mode: 'cors'` and `credentials: 'include'` for cross-origin webhook request

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c428434694832aa42fd46187aed7a7