### PR TITLE
Update sendToApi webhook URL

### DIFF
--- a/src/utils/webhook.ts
+++ b/src/utils/webhook.ts
@@ -18,7 +18,7 @@ export async function sendToApi(
 
   try {
     const response = await fetch(
-      "https://webhook.site/96185f74-ccf8-4346-87dd-79ad87de924a",
+      "https://webhook.targetfuturos.com/webhook/CriarInstancia",
       {
         method: "POST",
         mode: "cors",


### PR DESCRIPTION
## Summary
- point sendToApi to targetfuturos webhook

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c42b19cd08832a902a5effc120e7ce