### PR TITLE
Add status modal and color-coded API instances

### DIFF
--- a/src/components/InstanceDashboard.tsx
+++ b/src/components/InstanceDashboard.tsx
@@ -132,6 +132,14 @@ export function InstanceDashboard() {
     }
   };
 
+  const handleStatusUpdate = async (instanceId: string, status: InstanceStatus) => {
+    try {
+      await updateInstance(instanceId, { status });
+    } catch (error) {
+      console.error("Error updating status:", error);
+    }
+  };
+
   const handleQuickEditInstance = async (
     instanceId: string,
     data: {
@@ -561,6 +569,7 @@ export function InstanceDashboard() {
               instances={instances}
               loading={loading}
               onRemoveFromApi={handleRemoveFromApi}
+              onUpdateStatus={handleStatusUpdate}
             />
           </TabsContent>
 


### PR DESCRIPTION
## Summary
- sort API instances alphabetically
- color and animate API instance cards by status
- add status modal to update account status

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5185df9b8832aaeea6a825135fe1d