### PR TITLE
Improve API instance grid visuals

### DIFF
--- a/src/components/ApiInstancesGrid.tsx
+++ b/src/components/ApiInstancesGrid.tsx
@@ -38,10 +38,14 @@ export function ApiInstancesGrid({ instances, loading, onRemoveFromApi, onUpdate
     .sort((a, b) => a.instance_name.localeCompare(b.instance_name));
 
   const statusStyles: Record<InstanceStatus, string> = {
-    Repouso: "border-gray-200 bg-gray-100",
-    Aquecendo: "border-yellow-200 bg-yellow-50",
-    Disparando: "border-green-200 bg-green-50",
-    Banida: "border-red-200 bg-red-50",
+    Repouso:
+      "border-gray-200 bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-800 dark:to-gray-900",
+    Aquecendo:
+      "border-yellow-200 bg-gradient-to-br from-yellow-50 via-amber-50 to-yellow-100 dark:from-yellow-700 dark:via-amber-700 dark:to-yellow-800",
+    Disparando:
+      "border-green-200 bg-gradient-to-br from-green-50 to-emerald-100 dark:from-green-700 dark:to-emerald-800",
+    Banida:
+      "border-red-200 bg-gradient-to-br from-red-50 to-rose-100 dark:from-red-700 dark:to-rose-800",
   };
 
   const triggerWebhook = async (action: string, instanceId: string) => {
@@ -77,7 +81,7 @@ export function ApiInstancesGrid({ instances, loading, onRemoveFromApi, onUpdate
       {apiInstances.map((apiInstance) => (
         <Card
           key={apiInstance.id}
-          className={`${statusStyles[apiInstance.status]} transition-transform duration-300 hover:scale-105 animate-fade-in`}
+          className={`${statusStyles[apiInstance.status]} rounded-lg shadow-sm transition-all duration-300 hover:shadow-lg hover:scale-105 hover:-translate-y-1 animate-fade-in`}
         >
           <CardHeader>
             <CardTitle className="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- style API instance cards with gradient backgrounds and status colors
- add hover animations and shadows for livelier grid

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c51fab399c832abef0b166e60ea289