### PR TITLE
Sort API instances grid by instance ID

### DIFF
--- a/src/components/ApiInstancesGrid.tsx
+++ b/src/components/ApiInstancesGrid.tsx
@@ -35,7 +35,7 @@ export function ApiInstancesGrid({ instances, loading, onRemoveFromApi, onUpdate
 
   const apiInstances = instances
     .filter((inst) => inst.sent_to_api)
-    .sort((a, b) => a.instance_name.localeCompare(b.instance_name));
+    .sort((a, b) => a.instance_number - b.instance_number);
 
   const statusStyles: Record<InstanceStatus, string> = {
     Repouso:


### PR DESCRIPTION
## Summary
- Ensure API instances grid sorts by numeric instance ID for predictable ordering

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c526c1fc80832a82cf7a6e9a833f3f