### PR TITLE
Remove Chatwoot button from API instances

### DIFF
--- a/src/components/ApiInstancesGrid.tsx
+++ b/src/components/ApiInstancesGrid.tsx
@@ -95,9 +95,6 @@ export function ApiInstancesGrid({ instances, loading, onRemoveFromApi, onUpdate
               <Button onClick={() => triggerWebhook("connect", apiInstance.id)}>
                 Conectar
               </Button>
-              <Button onClick={() => triggerWebhook("chatwoot", apiInstance.id)}>
-                Chatwoot
-              </Button>
               <Button onClick={() => triggerWebhook("disconnect", apiInstance.id)}>
                 Desconectar
               </Button>


### PR DESCRIPTION
## Summary
- remove Chatwoot trigger button from API instances grid

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5279beed0832abc8a3ec0f89897c3