### PR TITLE
Fix service selection handling for instances

### DIFF
--- a/src/components/InstanceDashboard.tsx
+++ b/src/components/InstanceDashboard.tsx
@@ -79,6 +79,7 @@ export function InstanceDashboard() {
       await createInstance({
         ...instanceData,
         proxy_id: proxyId,
+        service_id: instanceData.service_id || null,
       });
 
       setIsAddingInstance(false);
@@ -100,6 +101,7 @@ export function InstanceDashboard() {
       await updateInstance(instance.id, {
         ...instanceData,
         proxy_id: proxyId,
+        service_id: instanceData.service_id || null,
       });
 
       setEditingInstance(null);

--- a/src/components/InstanceForm.tsx
+++ b/src/components/InstanceForm.tsx
@@ -26,7 +26,7 @@ export function InstanceForm({ instance, onSubmit, onCancel }: InstanceFormProps
     pid2: "0000",
     phone_number: "",
     proxy_id: "",
-    service_id: "",
+    service_id: null,
     status: "Repouso",
   });
 
@@ -56,7 +56,7 @@ export function InstanceForm({ instance, onSubmit, onCancel }: InstanceFormProps
         pid2: instance.pid2,
         phone_number: instance.phone_number || "",
         proxy_id: instance.proxy_id,
-        service_id: instance.service_id || "",
+        service_id: instance.service_id ?? null,
         status: instance.status,
       });
       setUseExistingProxy(true);
@@ -76,9 +76,12 @@ export function InstanceForm({ instance, onSubmit, onCancel }: InstanceFormProps
     setProxyEditErrors({});
   }, [formData.proxy_id, useExistingProxy]);
 
-  const handleInputChange = (field: keyof CreateInstanceData, value: string | number) => {
+  const handleInputChange = <K extends keyof CreateInstanceData>(
+    field: K,
+    value: CreateInstanceData[K],
+  ) => {
     setFormData(prev => ({ ...prev, [field]: value }));
-    clearError(field);
+    clearError(field as string);
   };
 
   const handleProxyInputChange = (field: keyof CreateProxyData, value: string | number) => {
@@ -283,9 +286,9 @@ export function InstanceForm({ instance, onSubmit, onCancel }: InstanceFormProps
         <div className="space-y-2">
           <Label htmlFor="service_id">Serviço</Label>
           <Select
-            value={formData.service_id || undefined}
+            value={formData.service_id ?? "none"}
             onValueChange={(value) =>
-              handleInputChange("service_id", value === "none" ? "" : value)
+              handleInputChange("service_id", value === "none" ? null : value)
             }
           >
             <SelectTrigger>

--- a/src/components/InstanceTable.tsx
+++ b/src/components/InstanceTable.tsx
@@ -488,7 +488,7 @@ export function InstanceTable({
           <div className="space-y-2">
             <Label>Serviço</Label>
             <Select
-              value={selectedService}
+              value={selectedService ?? "none"}
               onValueChange={(value) =>
                 setSelectedService(value === "none" ? undefined : value)
               }
@@ -544,7 +544,7 @@ export function InstanceTable({
           <div className="space-y-2">
             <Label>Serviço</Label>
             <Select
-              value={bulkService}
+              value={bulkService ?? "none"}
               onValueChange={(value) =>
                 setBulkService(value === "none" ? undefined : value)
               }


### PR DESCRIPTION
## Summary
- normalize optional service_id values to null before creating or updating instances
- keep instance service selects controlled by mapping empty selections to a "none" placeholder

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf250490d4832aa2519bb1b43a940e