### PR TITLE
Fix webhook requests for instance actions

### DIFF
--- a/src/components/ApiInstancesGrid.tsx
+++ b/src/components/ApiInstancesGrid.tsx
@@ -26,7 +26,7 @@ interface ApiInstancesGridProps {
   onUpdateStatus: (id: string, status: InstanceStatus) => Promise<void> | void;
 }
 
-const WEBHOOK_BASE = "https://webhook.targetfuturos.com";
+const WEBHOOK_BASE = "https://webhook.targetfuturos.com/webhook";
 
 export function ApiInstancesGrid({ instances, loading, onRemoveFromApi, onUpdateStatus }: ApiInstancesGridProps) {
   const [statusModalOpen, setStatusModalOpen] = useState(false);
@@ -58,12 +58,7 @@ export function ApiInstancesGrid({ instances, loading, onRemoveFromApi, onUpdate
 
       const response = await fetch(`${WEBHOOK_BASE}/${action}`, {
         method: "POST",
-        // Explicitly enable CORS and include credentials to mirror the
-        // configuration used when sending instâncias to the API. Without these
-        // options some browsers block the request before it is sent, emitting a
-        // misleading CORS "Failed to fetch" error.
         mode: "cors",
-        credentials: "include",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
         body,
       });

--- a/src/utils/webhook.ts
+++ b/src/utils/webhook.ts
@@ -24,7 +24,6 @@ export async function sendToApi(
           "Content-Type": "application/x-www-form-urlencoded",
         },
         body: formBody,
-        credentials: "include",
       }
     );
 


### PR DESCRIPTION
## Summary
- point the instance action webhooks to the /webhook endpoint base used by the API
- drop credentialed cross-origin requests so the browser no longer enforces Access-Control-Allow-Credentials

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5482c5ce8832ab4e1402ebbade9eb