### PR TITLE
Automate periodic API instance connection checks

### DIFF
--- a/src/components/InstanceDashboard.tsx
+++ b/src/components/InstanceDashboard.tsx
@@ -65,8 +65,6 @@ export function InstanceDashboard() {
   const [isAddingService, setIsAddingService] = useState(false);
   const [editingService, setEditingService] = useState<Service | null>(null);
   const [activeTab, setActiveTab] = useState("instances");
-  const [testAllTrigger, setTestAllTrigger] = useState(0);
-  const [isTestingAllConnections, setIsTestingAllConnections] = useState(false);
 
   const handleAddInstance = async (instanceData: CreateInstanceData, proxyData?: CreateProxyData) => {
     try {
@@ -334,8 +332,6 @@ export function InstanceDashboard() {
     (instance.proxies?.name || "").toLowerCase().includes(searchTerm.toLowerCase())
   );
 
-  const apiInstancesCount = instances.filter((instance) => instance.sent_to_api).length;
-
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-screen">
@@ -563,24 +559,12 @@ export function InstanceDashboard() {
           <TabsContent value="api-instances" className="space-y-4">
             <div className="flex justify-between items-center">
               <h2 className="text-xl font-semibold">Instâncias na API</h2>
-              <Button
-                onClick={() => setTestAllTrigger((prev) => prev + 1)}
-                disabled={
-                  isTestingAllConnections ||
-                  loading ||
-                  apiInstancesCount === 0
-                }
-              >
-                {isTestingAllConnections ? "Testando..." : "Testar todas as instâncias"}
-              </Button>
             </div>
             <ApiInstancesGrid
               instances={instances}
               loading={loading}
               onRemoveFromApi={handleRemoveFromApi}
               onUpdateStatus={handleStatusUpdate}
-              triggerTestAll={testAllTrigger}
-              onTestingAllChange={setIsTestingAllConnections}
             />
           </TabsContent>
 


### PR DESCRIPTION
## Summary
- remove the manual "Testar todas as instâncias" action from the API instances tab
- trigger each instance's connection test automatically on page load and every 30 minutes to keep statuses fresh
- memoize the filtered API instance list to avoid redundant re-renders while scheduling the automated tests

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d61592f360832aab674075f78871f9