### PR TITLE
Allow editing services in API instances modal

### DIFF
--- a/src/components/InstanceDashboard.tsx
+++ b/src/components/InstanceDashboard.tsx
@@ -130,11 +130,14 @@ export function InstanceDashboard() {
     }
   };
 
-  const handleStatusUpdate = async (instanceId: string, status: InstanceStatus) => {
+  const handleApiInstanceUpdate = async (
+    instanceId: string,
+    data: { status: InstanceStatus; service_id: string | null },
+  ) => {
     try {
-      await updateInstance(instanceId, { status });
+      await updateInstance(instanceId, data);
     } catch (error) {
-      console.error("Error updating status:", error);
+      console.error("Error updating API instance:", error);
     }
   };
 
@@ -576,7 +579,8 @@ export function InstanceDashboard() {
               instances={instances}
               loading={loading}
               onRemoveFromApi={handleRemoveFromApi}
-              onUpdateStatus={handleStatusUpdate}
+              onUpdateInstance={handleApiInstanceUpdate}
+              services={services}
             />
           </TabsContent>
 


### PR DESCRIPTION
## Summary
- rename the "Status" action in the API instances grid to "Editar"
- update the modal to support editing both instance status and assigned service
- wire the API instance edit flow to persist status and service changes through the dashboard

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d624c6a050832a9307cb44e0c5c8e7