### PR TITLE
Transform ZapGuardApp into account-based view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ const App = () => (
           <Route path="/" element={<Index />} />
           <Route path="/auth" element={<Auth />} />
           <Route path="/zapguardapp" element={<ZapGuardApp />} />
+          <Route path="/zapguardapp/:accountId" element={<ZapGuardApp />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>


### PR DESCRIPTION
## Summary
- allow accessing ZapGuardApp with an account id in the URL while keeping the legacy route available
- read the account id from the route instead of waiting for Chatwoot postMessages and surface validation errors
- reuse existing filtering to show a client’s services/instances once the account id resolves successfully

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d63656b0c0832aa7d3a5292657cd03