### PR TITLE
Remove client name display from ZapGuardApp cards

### DIFF
--- a/src/components/ApiInstancesGrid.tsx
+++ b/src/components/ApiInstancesGrid.tsx
@@ -725,9 +725,6 @@ export function ApiInstancesGrid({
                 Serviço: {apiInstance.services?.name ?? "Não atribuído"}
               </div>
               <div>
-                Cliente: {apiInstance.services?.clients?.name ?? "Não atribuído"}
-              </div>
-              <div>
                 Inbox ID: {apiInstance.inbox_id || "Não atribuído"}
               </div>
               <div className="space-y-2">


### PR DESCRIPTION
## Summary
- stop rendering the client name within ZapGuardApp API instance cards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d63a78aa18832abeb375487fb3910f