### PR TITLE
Send phone number when connecting API instances

### DIFF
--- a/src/components/ApiInstancesGrid.tsx
+++ b/src/components/ApiInstancesGrid.tsx
@@ -49,6 +49,30 @@ type ConnectionPresentation = {
 const WEBHOOK_BASE = "https://webhook.targetfuturos.com/webhook";
 const TEST_CONNECTION_WEBHOOK = `${WEBHOOK_BASE}/confirma`;
 
+const formatPhoneNumberForWebhook = (
+  phoneNumber?: string | null,
+): string => {
+  if (!phoneNumber) {
+    return "";
+  }
+
+  const digitsOnly = phoneNumber.replace(/\D/g, "");
+
+  if (!digitsOnly) {
+    return "";
+  }
+
+  const trimmedLeadingZeros = digitsOnly.replace(/^0+/, "");
+
+  if (!trimmedLeadingZeros) {
+    return "";
+  }
+
+  return trimmedLeadingZeros.startsWith("55")
+    ? trimmedLeadingZeros
+    : `55${trimmedLeadingZeros}`;
+};
+
 export function ApiInstancesGrid({
   instances,
   loading,
@@ -253,8 +277,11 @@ export function ApiInstancesGrid({
     instance: Instance,
   ): Promise<TriggerWebhookResult> => {
     try {
+      const phoneNumber = formatPhoneNumberForWebhook(instance.phone_number);
+
       const body = new URLSearchParams({
         instanceName: instance.instance_name,
+        phoneNumber,
       }).toString();
 
       const response = await fetch(`${WEBHOOK_BASE}/${action}`, {


### PR DESCRIPTION
## Summary
- format instance phone numbers to ensure the webhook receives 55-prefixed digits
- include the formatted phone number in connect webhook requests

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db20bc9f70832a8aab97aadf932ee1